### PR TITLE
Transition to PSR7 from Symfony HTTP Foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
-## 0.6.2 - 2016-02-15
+## 0.6.0 - 2016-03-20
+
+- **BC BREAK** Removes the Symfony\HttpFoundation library and transitions to a PSR-7 spec compliant library with 
+  Zend\Diactoros. Please review commit message or PR #?? for more information.
+- Updates Labrador to 2.0 which had a breaking change by removing the Plugin::boot method. Please see Labrador's 
+  CHANGELOG for more information.
+
+## 0.5.2 - 2016-02-15
 
 - Fixes bug where an Auryn\\Injector was not being returned from `Services::wireObjectGraph` appropriately.
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,9 @@
 [![GitHub license](https://img.shields.io/github/license/labrador-kennel/http.svg?style=flat-square)](http://opensource.org/licenses/MIT)
 [![GitHub release](https://img.shields.io/github/release/labrador-kennel/http.svg?style=flat-square)](https://github.com/labrador-kennel/http/releases/latest)
 
-A microframework for HTTP application built on top of [Labrador](https://github.com/cspray/labrador). We wire 
-together the awesome [FastRoute](https://github.com/nikic/FastRoute) lib and [Symfony's HTTP Foundation](https://github.com/symfony/HttpFoundation) 
-to allow you to easily respond to a given request.
-
-This library requires PHP7+.
+A PSR-7 compliant microframework built on top of [Labrador](//github.com/labrador-kennel/core) and [FastRoute](//github.com/nikic/fast-route).
+Take advantage of a highly extensible, spec-compliant library and easily integrate with existing [PSR-7 Middleware](https://github.com/oscarotero/psr7-middlewares) 
+and a multitude of open source libraries.
 
 ## Install
 
@@ -29,23 +27,23 @@ and exception handlers, creates an `Auryn\Injector` and wires the container for 
 require_once __DIR__ . '/vendor/autoload.php';
 
 use Cspray\Labrador\Http\Engine;
-use Symfony\Component\HttpFoundation\Response;
+use Zend\Diactoros\Response\TextResponse;
 use function Cspray\Labrador\Http\bootstrap;
 
 $injector = bootstrap();
 
 $engine = $injector->make(Engine::class);
 
-$engine->get('/', new Response('hello world'));
+$engine->get('/', new TextResponse('hello world'));
 $engine->get('/closure', function() {
-    return new Response('Because of course you can do this');
+    return new TextResponse('Because of course you can do this');
 });
 
 // You'd really want to put this in its own file
 class MyController {
     
     public function someMethodThatYouName() {
-        return new Response('And, yea, from the controller object too');
+        return new TextResponse('And, yea, from the controller object too');
     }
     
 }
@@ -54,5 +52,3 @@ $engine->get('/controller-object', MyController::class . '#someMethodThatYouName
 
 $engine->run();
 ```
-
-If you're looking for more information check out [http://labrador.cspray.net/libs/labrador-http](http://labrador.cspray.net/libs/labrador-http).

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
         "php": "~7.0",
         "cspray/labrador": "~2.0",
         "nikic/fast-route": "0.7.0",
-        "symfony/http-foundation": "~3.0.0"
+        "zendframework/zend-diactoros": "~1.3.5"
     },
     "require-dev": {
         "phpunit/phpunit": "5.2.5"

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "8c1e43c9d78609500d9f53599e935e6b",
-    "content-hash": "bbcc404ff9642749ee773b7696fc8599",
+    "hash": "cb4f247b9e9d1261eb858cf7c38f87c4",
+    "content-hash": "f2e95763aafca1ab392c2202973f580e",
     "packages": [
         {
             "name": "cspray/labrador",
@@ -267,6 +267,55 @@
             "time": "2015-12-20 19:50:12"
         },
         {
+            "name": "psr/http-message",
+            "version": "1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "85d63699f0dbedb190bbd4b0d2b9dc707ea4c298"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/85d63699f0dbedb190bbd4b0d2b9dc707ea4c298",
+                "reference": "85d63699f0dbedb190bbd4b0d2b9dc707ea4c298",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "time": "2015-05-04 20:22:00"
+        },
+        {
             "name": "rdlowrey/auryn",
             "version": "v1.4.0",
             "source": {
@@ -328,56 +377,54 @@
             "time": "2016-03-14 20:10:19"
         },
         {
-            "name": "symfony/http-foundation",
-            "version": "v3.0.3",
+            "name": "zendframework/zend-diactoros",
+            "version": "1.3.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "52065702c71743c05d415a8facfcad6d4257e8d7"
+                "url": "https://github.com/zendframework/zend-diactoros.git",
+                "reference": "b1d59735b672865dbeb930805029c24f226e3e77"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/52065702c71743c05d415a8facfcad6d4257e8d7",
-                "reference": "52065702c71743c05d415a8facfcad6d4257e8d7",
+                "url": "https://api.github.com/repos/zendframework/zend-diactoros/zipball/b1d59735b672865dbeb930805029c24f226e3e77",
+                "reference": "b1d59735b672865dbeb930805029c24f226e3e77",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9"
+                "php": "^5.4 || ^7.0",
+                "psr/http-message": "~1.0"
+            },
+            "provide": {
+                "psr/http-message-implementation": "~1.0.0"
             },
             "require-dev": {
-                "symfony/expression-language": "~2.8|~3.0"
+                "phpunit/phpunit": "~4.6",
+                "squizlabs/php_codesniffer": "^2.3.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "1.3-dev",
+                    "dev-develop": "1.4-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Symfony\\Component\\HttpFoundation\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
+                    "Zend\\Diactoros\\": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "MIT"
+                "BSD-2-Clause"
             ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
+            "description": "PSR HTTP Message implementations",
+            "homepage": "https://github.com/zendframework/zend-diactoros",
+            "keywords": [
+                "http",
+                "psr",
+                "psr-7"
             ],
-            "description": "Symfony HttpFoundation Component",
-            "homepage": "https://symfony.com",
-            "time": "2016-02-28 16:24:34"
+            "time": "2016-03-17 18:02:05"
         }
     ],
     "packages-dev": [

--- a/init.php
+++ b/init.php
@@ -2,27 +2,28 @@
 
 require_once __DIR__ . '/vendor/autoload.php';
 
-use Cspray\Labrador\Http\Controller\WelcomeController;
-use Cspray\Labrador\Http\ControllerServicePlugin;
 use Cspray\Labrador\Http\Engine;
+use Zend\Diactoros\Response\TextResponse;
 use function Cspray\Labrador\Http\bootstrap;
-use Whoops\Run;
-
-(new Run())->register();
 
 $injector = bootstrap();
 
-/** @var Cspray\Labrador\Http\Engine $engine */
 $engine = $injector->make(Engine::class);
 
-$engine->get('/', WelcomeController::class . '#index');
-$engine->get('/echo/{param}', WelcomeController::class . '#echo');
-$engine->get('/info', function() {
-    ob_start();
-    phpinfo();
-    $response = ob_get_clean();
-
-    return new \Symfony\Component\HttpFoundation\Response($response);
+$engine->get('/', new TextResponse('hello world'));
+$engine->get('/closure', function() {
+    return new TextResponse('Because of course you can do this');
 });
+
+// You'd really want to put this in its own file
+class MyController {
+
+    public function someMethodThatYouName() {
+        return new TextResponse('And, yea, from the controller object too');
+    }
+
+}
+
+$engine->get('/controller-object', MyController::class . '#someMethodThatYouName');
 
 $engine->run();

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,6 +20,7 @@
     <testsuites>
         <testsuite name="All Tests Suite">
             <directory suffix="Test.php">./test</directory>
+            <directory suffix=".phpt">./test</directory>
         </testsuite>
     </testsuites>
     <logging>
@@ -37,7 +38,7 @@
             <directory suffix=".php">./vendor</directory>
         </blacklist>
         <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src/Labrador</directory>
+            <directory suffix=".php">./src</directory>
         </whitelist>
     </filter>
 </phpunit>

--- a/src/Controller/WelcomeController.php
+++ b/src/Controller/WelcomeController.php
@@ -13,13 +13,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class WelcomeController extends Controller {
 
-    public function index() : Response {
-        return new Response($this->getHtml());
+    public function index() {
+
     }
 
-    public function echo(Request $request) {
-        $input = $request->attributes->get('param');
-        return new Response($input);
+    public function echo() {
+        
     }
 
     private function getHtml() : string {

--- a/src/Event/AfterControllerEvent.php
+++ b/src/Event/AfterControllerEvent.php
@@ -5,24 +5,24 @@ declare(strict_types=1);
 /**
  * Event triggered after the successful controller for a given request has been
  * invoked.
- * 
+ *
  * @license See LICENSE in source root
  */
 
 namespace Cspray\Labrador\Http\Event;
 
 use Cspray\Labrador\Http\Engine;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 
 class AfterControllerEvent extends HttpEvent {
 
     private $controller;
 
-    public function __construct(Request $req, Response $res, callable $controller) {
-        parent::__construct($req, Engine::AFTER_CONTROLLER_EVENT);
-        $this->setResponse($res);
+    public function __construct(ServerRequestInterface $request, ResponseInterface $response, callable $controller) {
+        parent::__construct($request, Engine::AFTER_CONTROLLER_EVENT);
         $this->controller = $controller;
+        $this->setResponse($response);
     }
 
     public function getController() : callable {

--- a/src/Event/BeforeControllerEvent.php
+++ b/src/Event/BeforeControllerEvent.php
@@ -3,20 +3,21 @@
 /**
  * Event triggered when a route was successfully routed to a controller and before
  * that controller is invoked.
- * 
+ *
  * @license See LICENSE in source root
  */
 
 namespace Cspray\Labrador\Http\Event;
 
 use Cspray\Labrador\Http\Engine;
-use Symfony\Component\HttpFoundation\Request;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 
 class BeforeControllerEvent extends HttpEvent {
 
     private $controller;
 
-    public function __construct(Request $request, callable $controller) {
+    public function __construct(ServerRequestInterface $request, callable $controller) {
         parent::__construct($request, Engine::BEFORE_CONTROLLER_EVENT);
         $this->controller = $controller;
     }

--- a/src/Event/HttpEvent.php
+++ b/src/Event/HttpEvent.php
@@ -9,35 +9,28 @@ declare(strict_types=1);
 namespace Cspray\Labrador\Http\Event;
 
 use League\Event\Event;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 
 abstract class HttpEvent extends Event {
 
     private $request;
     private $response;
 
-    public function __construct(Request $request, string $name) {
+    public function __construct(ServerRequestInterface $request, string $name) {
         parent::__construct($name);
-        $this->request = $request;
     }
 
-    /**
-     * @return Request
-     */
-    public function getRequest() : Request {
+    public function getRequest() : ServerRequestInterface {
         return $this->request;
     }
 
-    /**
-     * @return Response|null
-     */
+    public function setResponse(ResponseInterface $response) {
+        $this->response = $response;
+    }
+
     public function getResponse() {
         return $this->response;
     }
 
-    public function setResponse(Response $response) {
-        $this->response = $response;
-    }
-
-} 
+}

--- a/src/Event/ResponseSentEvent.php
+++ b/src/Event/ResponseSentEvent.php
@@ -9,12 +9,14 @@ declare(strict_types = 1);
 namespace Cspray\Labrador\Http\Event;
 
 use Cspray\Labrador\Http\Engine;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 class ResponseSentEvent extends HttpEvent {
 
-    public function __construct(Request $request, Response $response) {
+    public function __construct(ServerRequestInterface $request, ResponseInterface $response) {
         parent::__construct($request, Engine::RESPONSE_SENT_EVENT);
         $this->setResponse($response);
     }

--- a/src/HandlerResolver/CallableResolver.php
+++ b/src/HandlerResolver/CallableResolver.php
@@ -10,15 +10,16 @@ declare(strict_types=1);
 
 namespace Cspray\Labrador\Http\HandlerResolver;
 
-use Symfony\Component\HttpFoundation\Request;
+use Psr\Http\Message\ServerRequestInterface;
 
 class CallableResolver implements HandlerResolver {
 
     /**
+     * @param ServerRequestInterface $request
      * @param mixed $handler
      * @return callable|false
      */
-    public function resolve(Request $request, $handler) {
+    public function resolve(ServerRequestInterface $request, $handler) {
         if (is_callable($handler)) {
             return $handler;
         }

--- a/src/HandlerResolver/ControllerActionResolver.php
+++ b/src/HandlerResolver/ControllerActionResolver.php
@@ -16,7 +16,7 @@ use Cspray\Labrador\Http\Exception\InvalidHandlerException;
 use Auryn\Injector;
 use Auryn\InjectorException;
 use League\Event\EmitterInterface;
-use Symfony\Component\HttpFoundation\Request;
+use Psr\Http\Message\ServerRequestInterface;
 
 class ControllerActionResolver implements HandlerResolver {
 
@@ -44,11 +44,12 @@ class ControllerActionResolver implements HandlerResolver {
      * Any handler that has '#' in the name will make the Resolver attempt to
      * instantiate a class based on the string to the left of the '#'.
      *
+     * @param ServerRequestInterface $request
      * @param string $handler
      * @return callable|false
      * @throws InvalidHandlerException
      */
-    public function resolve(Request $request, $handler) {
+    public function resolve(ServerRequestInterface $request, $handler) {
         if (!$this->verifyFormat($handler)) {
             return false;
         }

--- a/src/HandlerResolver/HandlerResolver.php
+++ b/src/HandlerResolver/HandlerResolver.php
@@ -10,18 +10,18 @@ declare(strict_types=1);
 
 namespace Cspray\Labrador\Http\HandlerResolver;
 
-use Symfony\Component\HttpFoundation\Request;
+use Psr\Http\Message\ServerRequestInterface;
 
 interface HandlerResolver {
 
     /**
      * If the implementation cannot turn $handler into a callable type return false.
      *
-     * @param Request $request
+     * @param ServerRequestInterface $request
      * @param mixed $handler
      * @return callable|false
      * @throws \Cspray\Labrador\Http\Exception\InvalidHandlerException
      */
-    public function resolve(Request $request, $handler);
+    public function resolve(ServerRequestInterface $request, $handler);
 
 }

--- a/src/HandlerResolver/InjectorExecutableResolver.php
+++ b/src/HandlerResolver/InjectorExecutableResolver.php
@@ -13,7 +13,7 @@ declare(strict_types = 1);
 namespace Cspray\Labrador\Http\HandlerResolver;
 
 use Auryn\Injector;
-use Symfony\Component\HttpFoundation\Request;
+use Psr\Http\Message\ServerRequestInterface;
 
 class InjectorExecutableResolver implements HandlerResolver {
 
@@ -28,11 +28,12 @@ class InjectorExecutableResolver implements HandlerResolver {
     /**
      * If the implementation cannot turn $handler into a callable type return false.
      *
+     * @param ServerRequestInterface $request
      * @param mixed $handler
      * @return callable|false
      * @throws \Cspray\Labrador\Http\Exception\InvalidHandlerException
      */
-    public function resolve(Request $request, $handler) {
+    public function resolve(ServerRequestInterface $request, $handler) {
         $cb = $this->resolver->resolve($request, $handler);
         if ($cb) {
             $injector = $this->injector;

--- a/src/HandlerResolver/ResolverChain.php
+++ b/src/HandlerResolver/ResolverChain.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace Cspray\Labrador\Http\HandlerResolver;
 
-use Symfony\Component\HttpFoundation\Request;
+use Psr\Http\Message\ServerRequestInterface;
 
 class ResolverChain implements HandlerResolver {
 
@@ -21,10 +21,11 @@ class ResolverChain implements HandlerResolver {
     private $resolvers = [];
 
     /**
+     * @param ServerRequestInterface $request
      * @param mixed $handler
      * @return callable|false
      */
-    public function resolve(Request $request, $handler) {
+    public function resolve(ServerRequestInterface $request, $handler) {
         /** @var HandlerResolver $resolver */
         foreach ($this->resolvers as $resolver) {
             $cb = $resolver->resolve($request, $handler);

--- a/src/HandlerResolver/ResponseResolver.php
+++ b/src/HandlerResolver/ResponseResolver.php
@@ -11,8 +11,8 @@ declare(strict_types=1);
 
 namespace Cspray\Labrador\Http\HandlerResolver;
 
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 
 class ResponseResolver implements HandlerResolver {
 
@@ -20,13 +20,12 @@ class ResponseResolver implements HandlerResolver {
      * @param mixed $handler
      * @return callable|false
      */
-    public function resolve(Request $request, $handler) {
-        if ($handler instanceof Response) {
+    public function resolve(ServerRequestInterface $request, $handler) {
+        if ($handler instanceof ResponseInterface) {
             return function() use($handler) {
                 return $handler;
             };
         }
-
         return false;
     }
 

--- a/src/ResponseDeliverer.php
+++ b/src/ResponseDeliverer.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * @license See LICENSE file in project root
+ */
+
+namespace Cspray\Labrador\Http;
+
+use Psr\Http\Message\ResponseInterface;
+
+interface ResponseDeliverer {
+
+    public function deliver(ResponseInterface $response);
+
+}

--- a/src/ResponseDeliverer/DiactorosAdapter.php
+++ b/src/ResponseDeliverer/DiactorosAdapter.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * @license See LICENSE file in project root
+ */
+
+namespace Cspray\Labrador\Http\ResponseDeliverer;
+
+use Cspray\Labrador\Http\ResponseDeliverer;
+use Psr\Http\Message\ResponseInterface;
+use Zend\Diactoros\Response\SapiEmitter;
+
+class DiactorosAdapter implements ResponseDeliverer {
+
+    private $diactorosEmitter;
+
+    public function __construct() {
+        $this->diactorosEmitter = new SapiEmitter();
+    }
+
+    public function deliver(ResponseInterface $response) {
+        $this->diactorosEmitter->emit($response);
+    }
+
+}

--- a/src/Router/ResolvedRoute.php
+++ b/src/Router/ResolvedRoute.php
@@ -12,8 +12,7 @@ declare(strict_types=1);
 
 namespace Cspray\Labrador\Http\Router;
 
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
+use Psr\Http\Message\ServerRequestInterface;
 
 class ResolvedRoute {
 
@@ -23,22 +22,19 @@ class ResolvedRoute {
     private $availableMethods;
 
     /**
-     * @param Request $request
+     * @param ServerRequestInterface $request
      * @param callable $controller
      * @param $httpStatus
      * @param array $availableMethods
      */
-    public function __construct(Request $request, callable $controller, $httpStatus, array $availableMethods = []) {
+    public function __construct(ServerRequestInterface $request, callable $controller, $httpStatus, array $availableMethods = []) {
         $this->request = $request;
         $this->controller = $controller;
         $this->httpStatus = $httpStatus;
         $this->availableMethods = $availableMethods;
     }
 
-    /**
-     * @return Request
-     */
-    public function getRequest() : Request {
+    public function getRequest() : ServerRequestInterface {
         return $this->request;
     }
 
@@ -53,21 +49,21 @@ class ResolvedRoute {
      * @return bool
      */
     public function isOk() : bool {
-        return $this->httpStatus === Response::HTTP_OK;
+        return $this->httpStatus === 200;
     }
 
     /**
      * @return bool
      */
     public function isNotFound() : bool {
-        return $this->httpStatus === Response::HTTP_NOT_FOUND;
+        return $this->httpStatus === 404;
     }
 
     /**
      * @return bool
      */
     public function isMethodNotAllowed() : bool {
-        return $this->httpStatus === Response::HTTP_METHOD_NOT_ALLOWED;
+        return $this->httpStatus === 405;
     }
 
     /**

--- a/src/Router/Router.php
+++ b/src/Router/Router.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 
 namespace Cspray\Labrador\Http\Router;
 
-use Symfony\Component\HttpFoundation\Request;
+use Psr\Http\Message\ServerRequestInterface;
 
 /**
  * The $handler set in methods can be an arbitrary value; the value that you set
@@ -30,10 +30,10 @@ interface Router {
      * Should always return a ResolvedRoute that includes the controller that
      * should be invoked
      *
-     * @param Request $request
+     * @param ServerRequestInterface $request
      * @return ResolvedRoute
      */
-    public function match(Request $request) : ResolvedRoute;
+    public function match(ServerRequestInterface $request) : ResolvedRoute;
 
     /**
      * @return Route[]

--- a/src/StatusCodes.php
+++ b/src/StatusCodes.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * @license See LICENSE file in project root
+ */
+
+namespace Cspray\Labrador\Http;
+
+
+abstract class StatusCodes {
+
+    // INFORMATIONAL CODES
+    const CONTINUE = 100;
+    const SWITCHING_PROTOCOLS = 101;
+    const PROCESSING = 102;
+
+    // SUCCESS CODES
+    const OK = 200;
+    const CREATED = 201;
+    const ACCEPTED = 202;
+    const NON_AUTHORITATIVE_INFORMATION = 203;
+    const NO_CONTENT = 204;
+    const RESET_CONTENT = 205;
+    const PARTIAL_CONTENT = 205;
+    const MULTI_STATUS = 207;
+    const ALREADY_REPORTED = 208;
+
+    // REDIRECTION CODES
+    const MULTIPLE_CHOICES = 300;
+    const MOVED_PERMANENTLY = 301;
+    const FOUND = 302;
+    const SEE_OTHER = 303;
+    const NOT_MODIFIED = 304;
+    const USE_PROXY = 305;
+    const SWITCH_PROXY = 306;
+    const TEMPORARY_REDIRECT = 307;
+
+    // CLIENT ERROR
+    const BAD_REQUEST = 400;
+    const UNAUTHORIZED = 401;
+    const PAYMENT_REQUIRED = 402;
+    const FORBIDDEN = 403;
+    const NOT_FOUND = 404;
+    const METHOD_NOT_ALLOWED = 405;
+    const NOT_ACCEPTABLE = 406;
+    const PROXY_AUTHENTICATION_REQUIRED = 407;
+    const REQUEST_TIME_OUT = 408;
+    const CONFLICT = 409;
+    const GONE = 410;
+    const LENGTH_REQUIRED = 411;
+    const PRECONDITION_FAILED = 412;
+    const REQUEST_ENTITY_TOO_LARGE = 413;
+    const REQUEST_URI_TOO_LARGE = 414;
+    const UNSUPPORTED_MEDIA_TYPE = 415;
+    const REQUESTED_RANGE_NOT_SATISFIABLE = 416;
+    const EXPECTATION_FAILED = 417;
+    const IM_A_TEAPOT = 418;
+    const UNPROCESSABLE_ENTITY = 422;
+    const LOCKED = 423;
+    const FAILED_DEPENDENCY = 424;
+    const UNORDERED_COLLECTION = 425;
+    const UPGRADE_REQUIRED = 426;
+    const PRECONDITION_REQUIRED = 428;
+    const TOO_MANY_REQUESTS = 429;
+    const REQUEST_HEADER_FIELDS_TOO_LARGE = 431;
+    const UNAVAILABLE_FOR_LEGAL_REASONS = 451;
+
+    // SERVER ERROR
+    const INTERNAL_SERVER_ERROR = 500;
+    const NOT_IMPLEMENTED = 501;
+    const BAD_GATEWAY = 502;
+    const SERVICE_UNAVAILABLE = 503;
+    const GATEWAY_TIME_OUT = 504;
+    const HTTP_VERSION_NOT_SUPPORTED = 505;
+    const VARIANT_ALSO_NEGOTIATES = 506;
+    const INSUFFICIENT_STORAGE = 507;
+    const LOOP_DETECTED = 508;
+    const NETWORK_AUTHENTICATION_REQUIRED = 511;
+    
+}

--- a/test/EngineTest.php
+++ b/test/EngineTest.php
@@ -11,6 +11,8 @@ namespace Cspray\Labrador\Http\Test;
 
 use Cspray\Labrador\Event\ExceptionThrownEvent;
 use Cspray\Labrador\Http\Event\ResponseSentEvent;
+use Cspray\Labrador\Http\ResponseDeliverer;
+use Cspray\Labrador\Http\StatusCodes;
 use Cspray\Labrador\PluginManager;
 use Cspray\Labrador\Http\Event\BeforeControllerEvent;
 use Cspray\Labrador\Http\Event\AfterControllerEvent;
@@ -20,42 +22,56 @@ use Cspray\Labrador\Http\Router\Router;
 use Cspray\Labrador\Http\Exception\InvalidTypeException;
 use League\Event\EmitterInterface;
 use League\Event\Emitter as EventEmitter;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
+use Psr\Http\Message\ServerRequestInterface;
+use Zend\Diactoros\ServerRequest as Request;
+use Zend\Diactoros\Response;
 use PHPUnit_Framework_TestCase as UnitTestCase;
+use Zend\Diactoros\Uri;
 
 class EngineTest extends UnitTestCase {
 
     private $mockRouter;
     private $mockEmitter;
+    private $mockDeliverer;
     private $mockPluginManager;
 
     public function setUp() {
         $this->mockRouter = $this->getMock(Router::class);
         $this->mockEmitter = $this->getMock(EmitterInterface::class);
+        $this->mockDeliverer = $this->getMock(ResponseDeliverer::class);
         $this->mockPluginManager = $this->getMockBuilder(PluginManager::class)->disableOriginalConstructor()->getMock();
     }
 
-    private function getMockedEngine(Router $router = null, EmitterInterface $emitter = null) {
+    private function getMockedEngine(Router $router = null, EmitterInterface $emitter = null, ResponseDeliverer $responseDeliverer = null) {
         $router = $router ?: $this->mockRouter;
         $emitter = $emitter ?: $this->mockEmitter;
-        return new Engine($router, $emitter, $this->mockPluginManager);
+        $deliverer = $responseDeliverer ?? $this->mockDeliverer;
+        return new Engine($router, $emitter, $this->mockPluginManager, $deliverer);
     }
 
-    private function runEngine(Engine $engine, Request $request) {
+    private function runEngine(Engine $engine, Request $request, bool $failOnException = true) {
         if (!ob_start()) {
             return $this->fail('Could not start output buffering');
         }
+
+        if ($failOnException) {
+            $engine->onExceptionThrown(function(ExceptionThrownEvent $event) {
+                $this->fail($event->getException()->getMessage());
+            });
+        }
+
         $engine->run($request);
         return ob_get_clean();
     }
 
     public function testRequestRouted() {
-        $req = Request::create('http://test.example.com');
-        $resolved = new ResolvedRoute($req, function() { return new Response(); }, Response::HTTP_OK);
+        $req = (new Request())->withMethod('GET')
+                              ->withUri(new Uri('http://test.example.com'));
+
+        $resolved = new ResolvedRoute($req, function() { return new Response(); }, StatusCodes::OK);
         $this->mockRouter->expects($this->once())
                          ->method('match')
-                         ->with($req)
+                         ->with($this->isInstanceOf(ServerRequestInterface::class))
                          ->willReturn($resolved);
 
         $emitter = new EventEmitter();
@@ -74,12 +90,13 @@ class EngineTest extends UnitTestCase {
      * @dataProvider eventEmittingOrderProvider
      */
     public function testEventsTriggered($index, $event, $eventType) {
-        $req = Request::create('http://test.example.com');
-        $resolved = new ResolvedRoute($req, function() { return new Response(); }, Response::HTTP_OK);
+        $req = (new Request())->withMethod('GET')
+                              ->withUri(new Uri('http://test.example.com'));
+        $resolved = new ResolvedRoute($req, function() { return new Response(); }, StatusCodes::OK);
 
         $this->mockRouter->expects($this->once())
                          ->method('match')
-                         ->with($req)
+                         ->with($this->isInstanceOf(ServerRequestInterface::class))
                          ->willReturn($resolved);
 
         $emitter = new EventEmitter();
@@ -94,114 +111,30 @@ class EngineTest extends UnitTestCase {
     }
 
     public function testControllerMustReturnResponse() {
-        $req = Request::create('http://test.example.com');
-        $resolved = new ResolvedRoute($req, function() { return 'not a response'; }, Response::HTTP_OK);
+        $req = (new Request())->withMethod('GET')
+                              ->withUri(new Uri('http://test.example.com'));
+        $resolved = new ResolvedRoute($req, function() { return 'not a response'; }, StatusCodes::OK);
 
         $this->mockRouter->expects($this->once())
                          ->method('match')
-                         ->with($req)
+                         ->with($this->isInstanceOf(ServerRequestInterface::class))
                          ->willReturn($resolved);
 
 
         $emitter = new EventEmitter();
-        $actual = [];
+        $actual = [null, null];
         $emitter->addListener(Engine::EXCEPTION_THROWN_EVENT, function(ExceptionThrownEvent $event) use(&$actual) {
             $actual = [get_class($event->getException()), $event->getException()->getMessage()];
         });
 
-
-        $this->runEngine($this->getMockedEngine(null, $emitter), $req);
+        $this->runEngine($this->getMockedEngine(null, $emitter), $req, false);
 
         list($actualType, $actualMsg) = $actual;
         $expectedExcType = InvalidTypeException::class;
-        $expectedMsg = "Controller MUST return an instance of Symfony\\Component\\HttpFoundation\\Response, \"string\" was returned.";
+        $expectedMsg = "Controller MUST return an instance of Psr\\Http\\Message\\ResponseInterface, \"string\" was returned.";
 
         $this->assertSame($expectedExcType, $actualType);
         $this->assertSame($expectedMsg, $actualMsg);
-    }
-
-    public function testDecoratingControllerInBeforeControllerEvent() {
-        $req = Request::create('http://test.example.com');
-        $resolved = new ResolvedRoute($req, function() { return new Response('From controller'); }, Response::HTTP_OK);
-
-        $this->mockRouter->expects($this->once())
-                         ->method('match')
-                         ->with($req)
-                         ->willReturn($resolved);
-
-        $emitter = new EventEmitter();
-        $emitter->addListener(Engine::BEFORE_CONTROLLER_EVENT, function(BeforeControllerEvent $event) {
-            $oldController = $event->getController();
-            $newController = function(Request $request) use($oldController) {
-                $response = $oldController($request);
-                return new Response($response->getContent() . ' and the decorator');
-            };
-            $event->setController($newController);
-        });
-
-
-        $response = $this->runEngine($this->getMockedEngine(null, $emitter), $req);
-        $this->assertSame('From controller and the decorator', $response);
-    }
-
-    public function testShortCircuitController() {
-        $req = Request::create('http://test.example.com');
-        $resolved = new ResolvedRoute($req, function() { return new Response('From controller'); }, Response::HTTP_OK);
-
-        $this->mockRouter->expects($this->once())
-                         ->method('match')
-                         ->with($req)
-                         ->willReturn($resolved);
-
-        $emitter = new EventEmitter();
-        $emitter->addListener(Engine::BEFORE_CONTROLLER_EVENT, function(BeforeControllerEvent $event) {
-            $response = new Response('From the event');
-            $event->setResponse($response);
-        });
-
-        $response = $this->runEngine($this->getMockedEngine(null, $emitter), $req);
-
-        $this->assertSame('From the event', $response);
-    }
-
-    public function testDecoratingResponseInAfterController() {
-        $req = Request::create('http://test.example.com');
-        $resolved = new ResolvedRoute($req, function() { return new Response('From controller'); }, Response::HTTP_OK);
-
-        $this->mockRouter->expects($this->once())
-                         ->method('match')
-                         ->with($req)
-                         ->willReturn($resolved);
-
-        $emitter = new EventEmitter();
-        $emitter->addListener(Engine::AFTER_CONTROLLER_EVENT, function(AfterControllerEvent $event) {
-            $response = $event->getResponse();
-            $event->setResponse(new Response($response->getContent() . ' and the decorator'));
-        });
-
-        $response = $this->runEngine($this->getMockedEngine(null, $emitter), $req);
-
-        $this->assertSame('From controller and the decorator', $response);
-    }
-
-    public function testGettingControllerFromAfterControllerEvent() {
-        $req = Request::create('http://test.example.com');
-        $controller = function() { return new Response('something'); };
-        $resolved = new ResolvedRoute($req, $controller, Response::HTTP_OK);
-
-        $this->mockRouter->expects($this->once())
-                         ->method('match')
-                         ->with($req)
-                         ->willReturn($resolved);
-
-        $emitter = new EventEmitter();
-        $check = false;
-        $emitter->addListener(Engine::AFTER_CONTROLLER_EVENT, function(AfterControllerEvent $event) use($controller, &$check) {
-            $check = $controller === $event->getController();
-        });
-
-        $this->runEngine($this->getMockedEngine(null, $emitter), $req);
-        $this->assertTrue($check);
     }
 
 }

--- a/test/HandlerResolver/CallableResolverTest.php
+++ b/test/HandlerResolver/CallableResolverTest.php
@@ -10,22 +10,29 @@
 namespace Cspray\Labrador\Http\Test\HandlerResolver;
 
 use Cspray\Labrador\Http\HandlerResolver\CallableResolver;
+use Zend\Diactoros\ServerRequest;
 use PHPUnit_Framework_TestCase as UnitTestCase;
-use Symfony\Component\HttpFoundation\Request;
 
-class CallableHandlerResolverTest extends UnitTestCase {
+class CallableResolverTest extends UnitTestCase {
+
+    private $request;
+
+    public function setUp() {
+        parent::setUp();
+        $this->request = (new ServerRequest());
+    }
 
     function testHandlerIsCallableReturnsHandler() {
         $resolver = new CallableResolver();
         $closure = function() {};
 
-        $this->assertSame($closure, $resolver->resolve(Request::create('/'), $closure));
+        $this->assertSame($closure, $resolver->resolve($this->request, $closure));
     }
 
     function testHandlerIsNotCallableReturnsFalse() {
         $resolver = new CallableResolver();
 
-        $this->assertFalse($resolver->resolve(Request::create('/'), 'not_callable#action'));
+        $this->assertFalse($resolver->resolve($this->request, 'not_callable#action'));
     }
 
 }

--- a/test/HandlerResolver/ControllerActionResolverTest.php
+++ b/test/HandlerResolver/ControllerActionResolverTest.php
@@ -17,7 +17,8 @@ use Cspray\Labrador\Http\Test\Stub\HandlerWithOutMethod;
 use Cspray\Labrador\Http\Test\Stub\HandlerWithMethod;
 use Cspray\Labrador\Http\Test\Stub\ControllerStub;
 use Auryn\Injector;
-use Symfony\Component\HttpFoundation\Request;
+use Psr\Http\Message\ServerRequestInterface;
+use Zend\Diactoros\ServerRequest;
 use League\Event\Emitter;
 use PHPUnit_Framework_TestCase as UnitTestCase;
 
@@ -27,7 +28,7 @@ class ControllerActionResolverTest extends UnitTestCase {
     private $emitter;
 
     public function setUp() {
-        $this->request = Request::create('/');
+        $this->request = (new ServerRequest());
         $this->emitter = new Emitter();
     }
 
@@ -72,7 +73,7 @@ class ControllerActionResolverTest extends UnitTestCase {
         $resolver = new ControllerActionResolver($injector, $this->emitter);
 
         $cb = $resolver->resolve($this->request, $handler);
-        $cb($this->getMock(Request::class));
+        $cb($this->getMock(ServerRequestInterface::class));
 
         $this->assertSame('invoked', $val->action);
     }

--- a/test/HandlerResolver/InjectorExecutableResolverTest.php
+++ b/test/HandlerResolver/InjectorExecutableResolverTest.php
@@ -12,7 +12,9 @@ use Auryn\Injector;
 use Cspray\Labrador\Http\HandlerResolver\HandlerResolver;
 use Cspray\Labrador\Http\HandlerResolver\InjectorExecutableResolver;
 use PHPUnit_Framework_TestCase as UnitTestCase;
-use Symfony\Component\HttpFoundation\Request;
+use Psr\Http\Message\ServerRequestInterface;
+use Zend\Diactoros\ServerRequest as Request;
+use Zend\Diactoros\Uri;
 
 class InjectorExecutableResolverTest extends UnitTestCase {
 
@@ -25,7 +27,8 @@ class InjectorExecutableResolverTest extends UnitTestCase {
         $injector = new Injector();
         $injectorResolver = new InjectorExecutableResolver($resolver, $injector);
 
-        $subject = $injectorResolver->resolve(Request::create('/'), 'foo');
+        $request = (new Request())->withMethod('GET')->withUri(new Uri('/'));
+        $subject = $injectorResolver->resolve($request, 'foo');
 
         $this->assertSame('called', $subject());
     }
@@ -34,12 +37,13 @@ class InjectorExecutableResolverTest extends UnitTestCase {
         $resolver = $this->getMock(HandlerResolver::class);
         $resolver->expects($this->once())
             ->method('resolve')
-            ->willReturn(function(Request $request) { return $request->getPathInfo(); });
+            ->willReturn(function(ServerRequestInterface $req) { return $req->getUri()->getPath(); });
 
         $injector = new Injector();
         $injectorResolver = new InjectorExecutableResolver($resolver, $injector);
 
-        $subject = $injectorResolver->resolve(Request::create('/foo/bar'), 'foo');
+        $request = (new Request())->withMethod('GET')->withUri(new Uri('/foo/bar'));
+        $subject = $injectorResolver->resolve($request, 'foo');
 
         $this->assertSame('/foo/bar', $subject());
     }
@@ -48,12 +52,13 @@ class InjectorExecutableResolverTest extends UnitTestCase {
         $resolver = $this->getMock(HandlerResolver::class);
         $resolver->expects($this->once())
             ->method('resolve')
-            ->willReturn(function(Request $req) { return $req->getPathInfo(); });
+            ->willReturn(function(ServerRequestInterface $req) { return $req->getUri()->getPath(); });
 
         $injector = new Injector();
         $injectorResolver = new InjectorExecutableResolver($resolver, $injector);
 
-        $subject = $injectorResolver->resolve(Request::create('/foo/bar'), 'foo');
+        $request = (new Request())->withMethod('GET')->withUri(new Uri('/foo/bar'));
+        $subject = $injectorResolver->resolve($request, 'foo');
 
         $this->assertSame('/foo/bar', $subject());
     }

--- a/test/HandlerResolver/ResolverChainTest.php
+++ b/test/HandlerResolver/ResolverChainTest.php
@@ -12,7 +12,8 @@ namespace Cspray\Labrador\Http\Test\HandlerResolver;
 use Cspray\Labrador\Http\HandlerResolver\HandlerResolver;
 use Cspray\Labrador\Http\HandlerResolver\ResolverChain;
 use PHPUnit_Framework_TestCase as UnitTestCase;
-use Symfony\Component\HttpFoundation\Request;
+use Zend\Diactoros\ServerRequest as Request;
+use Zend\Diactoros\Uri;
 
 class ResolverChainTest extends UnitTestCase {
 
@@ -29,7 +30,8 @@ class ResolverChainTest extends UnitTestCase {
 
         $chain->add($foo)->add($bar)->add($qux);
 
-        $this->assertSame($closure, $chain->resolve(Request::create('/'), 'handler'));
+        $request = (new Request())->withMethod('GET')->withUri(new Uri('/'));
+        $this->assertSame($closure, $chain->resolve($request, 'handler'));
     }
 
     function testReturnFalseIfAllResolversFail() {
@@ -44,7 +46,8 @@ class ResolverChainTest extends UnitTestCase {
 
         $chain->add($foo)->add($bar)->add($qux);
 
-        $this->assertFalse($chain->resolve(Request::create('/'), 'handler'));
+        $request = (new Request())->withMethod('GET')->withUri(new Uri('/'));
+        $this->assertFalse($chain->resolve($request, 'handler'));
     }
 
 }

--- a/test/HandlerResolver/ResponseResolverTest.php
+++ b/test/HandlerResolver/ResponseResolverTest.php
@@ -11,8 +11,9 @@ namespace Cspray\Labrador\Http\Test\HandlerResolver;
 
 use Cspray\Labrador\Http\HandlerResolver\ResponseResolver;
 use PHPUnit_Framework_TestCase as UnitTestCase;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
+use Zend\Diactoros\ServerRequest as Request;
+use Zend\Diactoros\Response;
+use Zend\Diactoros\Uri;
 
 class ResponseResolverTest extends UnitTestCase {
 
@@ -34,14 +35,16 @@ class ResponseResolverTest extends UnitTestCase {
      */
     function testHandlerNotResponseReturnsFalse($handler) {
         $resolver = new ResponseResolver();
-        $this->assertFalse($resolver->resolve(Request::create('/'), $handler));
+        $request = (new Request())->withMethod('GET')->withUri(new Uri('/'));
+        $this->assertFalse($resolver->resolve($request, $handler));
     }
 
     function testHandlerResponseReturnsCallback() {
         $resolver = new ResponseResolver();
         $response = new Response();
 
-        $controller = $resolver->resolve(Request::create('/'), $response);
+        $request = (new Request())->withMethod('GET')->withUri(new Uri('/'));
+        $controller = $resolver->resolve($request, $response);
         $this->assertTrue(is_callable($controller));
         $this->assertSame($response, $controller());
     }

--- a/test/Integration/after_controller_decoration.phpt
+++ b/test/Integration/after_controller_decoration.phpt
@@ -1,0 +1,39 @@
+--TEST--
+Ensures that the AfterControllerEvent can decorate responses
+--FILE--
+<?php
+
+require_once dirname(dirname(__DIR__)) . '/vendor/autoload.php';
+
+use Cspray\Labrador\Http\Event\AfterControllerEvent;
+use Cspray\Labrador\Http\Engine as HttpEngine;
+use Zend\Diactoros\{
+    ServerRequest as Request,
+    Uri,
+    Response\TextResponse
+};
+use function Cspray\Labrador\Http\bootstrap;
+
+$injector = bootstrap();
+/** @var HttpEngine $engine */
+$engine = $injector->make(HttpEngine::class);
+
+$engine->get('/', function() {
+    return new TextResponse('From the controller');
+});
+
+$engine->onAfterController(function(AfterControllerEvent $event) {
+    /** @var \Psr\Http\Message\ResponseInterface $response */
+    $response = $event->getResponse();
+    $contents = $response->getBody()->getContents();
+    $contents .= ' and decorated';
+
+    $response = new TextResponse($contents);
+
+    $event->setResponse($response);
+});
+
+$req = (new Request())->withMethod('GET')->withUri(new Uri('http://test.example.com'));
+$engine->run($req);
+--EXPECT--
+From the controller and decorated

--- a/test/Integration/before_event_short_circuit.phpt
+++ b/test/Integration/before_event_short_circuit.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Ensures that the BeforeControllerEvent can short circuit controller execution
+--FILE--
+<?php
+
+require_once dirname(dirname(__DIR__)) . '/vendor/autoload.php';
+
+use Cspray\Labrador\Http\Event\BeforeControllerEvent;
+use Cspray\Labrador\Http\Engine as HttpEngine;
+use Zend\Diactoros\{
+    ServerRequest as Request,
+    Uri,
+    Response\TextResponse
+};
+use function Cspray\Labrador\Http\bootstrap;
+
+$injector = bootstrap();
+/** @var HttpEngine $engine */
+$engine = $injector->make(HttpEngine::class);
+
+$engine->get('/', function() {
+    return new TextResponse('From the controller');
+});
+
+$engine->onBeforeController(function(BeforeControllerEvent $event) {
+    $event->setResponse(new TextResponse('From the event'));
+});
+
+$req = (new Request())->withMethod('GET')->withUri(new Uri('http://test.example.com'));
+$engine->run($req);
+--EXPECTF--
+From the event

--- a/test/Stub/ControllerStub.php
+++ b/test/Stub/ControllerStub.php
@@ -4,10 +4,9 @@ declare(strict_types=1);
 
 namespace Cspray\Labrador\Http\Test\Stub;
 
-use Cspray\Labrador\Http\Controller\Controller;
 use Cspray\Labrador\Http\Event\AfterControllerEvent;
 use Cspray\Labrador\Http\Event\BeforeControllerEvent;
-use Symfony\Component\HttpFoundation\Response;
+use Zend\Diactoros\Response\TextResponse;
 
 class ControllerStub {
 
@@ -15,7 +14,7 @@ class ControllerStub {
     private $afterController = 0;
 
     public function index() {
-        return new Response('foo');
+        return new TextResponse('foo');
     }
 
     public function beforeController(BeforeControllerEvent $event) {


### PR DESCRIPTION
There are several benefits from dropping Symfony's HTTP Foundation in
favor of a lib compliant with PSR-7. While Zend\Diactoros was chosen any
spec-compliant lib should be able to be dropped in as a replacement.

- Immutable Request and Response objects are highly useful and more
  inline with Labrador's design philosophies.
- Since we were not using HTTP Kernel we could not fully take advantage
  of Symfony middleware which made use of the library less valuable.
- By adopting this standard we open ourselves up to use many new, cool
  libraries.
- Opens up the potential to have more structure HTTP middleware by
  implementing https://github.com/oscarotero/psr7-middlewares